### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 * @FundingCircle/engineers
 
 # See https://fundingcircle.github.io/fc4-framework/ and https://github.com/FundingCircle/fc4-framework/
-*fc4* @FundingCircle/internal-documentation
+*fc4* @FundingCircle/architecture


### PR DESCRIPTION
As the Internal Documentation team is defunct, and the new Architecture
team has taken responsibility for FC4.