### PR TITLE
Test against macOS Catalina

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ workflows:
       #- audit:
       #    name: "audit-macos-mojave"
       #    version: "10.3.0"
+      #- audit:
+      #    name: "audit-macos-catalina"
+      #    version: "11.3.0"
       - test:
           name: "test-macos-high-sierra"
           version: "10.2.3"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
     parameters:
       version:
         description: "Xcode version"
-        default: "10.2.1"
+        default: "11.3.0"
         type: string
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
     parameters:
       version:
         description: "Xcode version"
-        default: "10.2.1"
+        default: "11.3.0"
         type: string
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,3 +72,6 @@ workflows:
       - test:
           name: "test-macos-mojave"
           version: "10.3.0"
+      - test:
+          name: "test-macos-catalina"
+          version: "11.3.0"


### PR DESCRIPTION
💁 macOS "Catalina" was released in October 2019. Probably a good time to start testing against it!

(The Xcode version string was taken from https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions)