### PR TITLE
Fix params of CircleCI executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,21 +5,23 @@ executors:
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     macos:
-      xcode: << parameters.version >>
+      xcode: << parameters.xcode-version >>
     parameters:
-      version:
-        description: "Xcode version"
-        default: "11.3.0"
-        type: string
+      xcode-version:
+        description: Determines the version of MacOS that will be used for a job.
+        type: enum
+        enum:
+          # See https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
+          - "10.1.0" # MacOS “High Sierra” 10.13.6
+          - "11.1.0" # MacOS “Mojave” 10.14.4
+          - "11.3.0" # MacOS “Catalina” 10.15.1
 
 jobs:
   audit:
-    executor: macos
+    executor: << parameters.e >>
     parameters:
-      version:
-        description: "Xcode version"
-        default: "11.3.0"
-        type: string
+      e:
+        type: executor
     steps:
       - checkout
       - restore_cache:
@@ -35,13 +37,12 @@ jobs:
           key: homebrew-floss-{{ checksum ".circleci/config.yml" }}
           paths:
             - /usr/local/Homebrew/Library/Homebrew/vendor/bundle
+
   test:
-    executor: macos
+    executor: << parameters.e >>
     parameters:
-      version:
-        description: "Xcode version"
-        default: "10.2.1"
-        type: string
+      e:
+        type: executor
     steps:
       - checkout
       - run:
@@ -54,27 +55,34 @@ jobs:
             done
 
 workflows:
-  ci:
+  Test:
     jobs:
-      # These jobs will fail until the format of fc4-tool release names
-      # is changed to remove underscores in the version component.
-      # This change is being tracked in:
-      # https://github.com/FundingCircle/fc4-framework/issues/193
-      #- audit:
-      #    name: "audit-macos-high-sierra"
-      #    version: "10.2.3"
-      #- audit:
-      #    name: "audit-macos-mojave"
-      #    version: "10.3.0"
-      #- audit:
-      #    name: "audit-macos-catalina"
-      #    version: "11.3.0"
       - test:
-          name: "test-macos-high-sierra"
-          version: "10.2.3"
+          name: Test (MacOS High Sierra)
+          e:
+            name: macos
+            xcode-version: "10.1.0"
       - test:
-          name: "test-macos-mojave"
-          version: "10.3.0"
+          name: Test (MacOS Mojave)
+          e:
+            name: macos
+            xcode-version: "11.1.0"
       - test:
-          name: "test-macos-catalina"
-          version: "11.3.0"
+          name: Test (MacOS Catalina)
+          e:
+            name: macos
+            xcode-version: "11.3.0"
+
+  # This workflow is commented out because these jobs will fail until the problem described here:
+  # https://github.com/FundingCircle/homebrew-floss/issues/9 is fixed.
+  # Audit:
+  #   jobs:
+  #     - audit:
+  #        name: Audit (MacOS High Sierra)
+  #        xcode-version: "10.2.3"
+  #     - audit:
+  #        name: Audit (MacOS Mojave)
+  #        xcode-version: "10.3.0"
+  #     - audit:
+  #        name: Audit (MacOS Catalina)
+  #        xcode-version: "11.3.0"


### PR DESCRIPTION
I was reviewing #15 when I noticed that when the jobs referenced the
`macos` executor, they were never supplying a value for the executor’s
param `version` — and that this meant that the default value of the
param was being used for every job instance. This meant that even though
in the workflow it _seemed_ like we were defining three different
instances of the `test` job, and that each instance would run on
different version of MacOS, they were in fact always running on the same
version; the one that was the default value of the param.

This is a fairly well-known risk of defining default values for params:
sometimes one may end up inadvertently using that default and not
realizing it. That’s why it’s often safer to omit a default value and
instead require callers to supply a param.

So that’s the core change I’ve made here: I’ve removed the default value
for the param `version` from the executor.

While I was at it, I made some additional tweaks:

* Renamed the executor param `version` to `xcode-version` just to be a
  little clearer and more explicit
* Changed the type of `xcode-version` from a string to an enumeration,
  just to add a little more rigor/safety to its use
* Updated the versions of Xcode that are allowed/used to the latest
  versions I saw listed in
  https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
  for each edition of MacOS.
* Replaced the job params named `version` of type string with a param
  named `e` of type `executor`
  * Docs here: https://circleci.com/docs/2.0/reusing-config/#executor
* Moved the commented-out audit jobs into their own commented-out
  workflow.
  * This just seems a little cleaner and clearer to me.