### PR TITLE
Calling depends_on :java is deprecated

### DIFF
--- a/fc4.rb
+++ b/fc4.rb
@@ -7,7 +7,7 @@ class Fc4 < Formula
   sha256 "6636e51a5f42ddc99ecbae11e6fa5e846b42f951e75a7720398513037028cb53"
 
   bottle :unneeded
-  depends_on :java => "1.8+"
+  depends_on "openjdk@8"
 
   resource "test_diagram_source" do
     url "https://raw.githubusercontent.com/FundingCircle/fc4-framework/c582061ef9d5ad6d680eed71cd55bb2d1e8c3230/docs/tool/fc4-tool-01-context.yaml"


### PR DESCRIPTION
When upgrading `okta_aws` I got

```
Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the fundingcircle/floss tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/fundingcircle/homebrew-floss/fc4.rb:10
```